### PR TITLE
fix: 레벨별 스킬 습득 로직, 스킬 사용 로그

### DIFF
--- a/Spartale/Source/Framework/AbilitySystem/AbilitySystemComponent.cpp
+++ b/Spartale/Source/Framework/AbilitySystem/AbilitySystemComponent.cpp
@@ -2,6 +2,7 @@
 #include "Framework/AbilitySystem/AttributeSet.h"
 #include "Framework/AbilitySystem/GameplayAbility.h"
 #include "Framework/AbilitySystem/GameplayEffect.h"
+#include "GameLogic/Skills/SkillFactory.h"
 #include "Core/Actor.h"
 
 #include <algorithm> // std::max 사용을 위해 포함
@@ -36,6 +37,7 @@ bool AbilitySystemComponent::CheckAndProcessLevelUp()
     float requiredExp = 50.0f * myStats->Level;
     bool bLeveledUp = false;
 
+
     // 현재 경험치가 필요 경험치보다 많으면 레벨업 (여러 번 레벨업 가능하도록 while 사용)
     while (myStats->Experience.CurrentValue >= requiredExp)
     {
@@ -48,6 +50,8 @@ bool AbilitySystemComponent::CheckAndProcessLevelUp()
         // 레벨 1 증가
         myStats->Level++;
 
+        // 레벨을 인덱스로 사용해 각 레벨에 맞는 스킬을 습득
+        OwnerActor->GetAbilityComponent()->GrantAbility(SkillFactory::CreateSkill(allSkillIDs[myStats->Level - 2]));
         bLeveledUp = true;
 
         // 레벨업 보상 (스탯 포인트 5 지급)

--- a/Spartale/Source/Framework/AbilitySystem/AbilitySystemComponent.h
+++ b/Spartale/Source/Framework/AbilitySystem/AbilitySystemComponent.h
@@ -72,4 +72,17 @@ protected:
 
     // 이 캐릭터에게 현재 적용 중인 모든 지속/영구 효과 목록 (게시판 역할)
     std::vector<FActiveGameplayEffect> ActiveEffects;
+
+    // 각 레벨별 추가할 스킬 목록
+    const std::vector<std::string> allSkillIDs = {
+        "SK_Meditate",
+        "SK_StrengthBuff",
+        "SK_Fireball",
+        "SK_PoisonCloud",
+        "SK_ArcaneBlast",
+        "SK_TripleSlash",
+        "SK_Heal",
+        "SK_AbyssalCollapse",
+        "SK_Judgment"
+    };
 };

--- a/Spartale/Source/GameLogic/BattleManager.cpp
+++ b/Spartale/Source/GameLogic/BattleManager.cpp
@@ -6,6 +6,7 @@
 #include "Framework/AbilitySystem/GameplayAbility.h"
 #include "Utils/ConsoleUtils.h"
 #include "Utils/ConsoleRenderer.h"
+#include "Utils/StringUtils.h"
 
 #include <algorithm>
 #include <iostream>
@@ -325,12 +326,18 @@ void BattleManager::EndBattle()
             LogAndWait(rewardMessage);
 
             // 레벨업 체크
-            bool bLeveledUp = m_player->GetAbilityComponent()->CheckAndProcessLevelUp();
+
+            AbilitySystemComponent* playerASC = m_player->GetAbilityComponent();
+            bool bLeveledUp = playerASC->CheckAndProcessLevelUp();
 
             // 레벨업
             if (bLeveledUp)
             {
                 std::wstring levelUpMessage = m_player->Name + L"은(는) 레벨 업 했다!";
+                LogAndWait(levelUpMessage);
+
+                std::wstring skillName = playerASC->GetGrantedAbility(playerASC->GetAttributeSet()->Level - 1)->AbilityName;
+                levelUpMessage = m_player->Name + L"은(는) " + skillName + L"을(를) 배웠다!";
                 LogAndWait(levelUpMessage);
             }
             break;

--- a/Spartale/Source/GameLogic/PauseMenu.cpp
+++ b/Spartale/Source/GameLogic/PauseMenu.cpp
@@ -247,20 +247,13 @@ void PauseMenu::DrawStatDistributionScreen()
     for (size_t i = 0; i < statNames.size(); ++i)
     {
         int currentStatY = contentY + i * 2;
-        WORD attributes = 0x000F; // 기본 흰색
         std::wstring cursor = L"  ";
-
-        if (i == m_statSelection)
-        {
-            attributes = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY; // 밝은 노란색
-            cursor = L"▶ ";
-        }
 
         // 스탯 이름 (왼쪽 정렬)
         m_renderer.DrawString(contentX, currentStatY, cursor + statNames[i]);
         // 스탯 값 (오른쪽 정렬)
         std::wstring valueStr = std::to_wstring(static_cast<int>(statValues[i]));
-        m_renderer.DrawString(boxX + boxInnerWidth - 1 - valueStr.length(), currentStatY, valueStr, attributes);
+        m_renderer.DrawString(boxX + boxInnerWidth - 1 - valueStr.length(), currentStatY, valueStr);
     }
 
     // 하단 안내 메시지 표시
@@ -440,10 +433,10 @@ void PauseMenu::DrawInventoryScreen()
     if (!inventory) return;
 
     int boxX = m_renderer.GetWidth() / 2 + 5;
-    int boxY = 6;
+    int boxY = 9; // 6
     int boxInnerWidth = 26;
     int boxHeight = 3;
-    const int visibleSlots = 8; // 한 화면에 보여줄 아이템 개수
+    const int visibleSlots = 5; // 한 화면에 보여줄 아이템 개수
 
     m_renderer.DrawString(boxX, boxY, L"      [ 인벤토리 ]");
     boxY += 2;
@@ -498,7 +491,8 @@ void PauseMenu::DrawInventoryScreen()
         }
     }
 
-    m_renderer.DrawString(m_renderer.GetWidth() / 2 + 3, m_renderer.GetHeight() - 4, L"[Enter: 선택 | ESC: 뒤로 가기]");
+    m_renderer.DrawString(m_renderer.GetWidth() / 2 + 3, m_renderer.GetHeight() - 2, L"[Enter: 선택 | ESC: 뒤로 가기]");
+    // 하단 안내 문구
 
     // 아이템 정보창은 항상 그림
     DrawItemInfoBox();
@@ -529,12 +523,14 @@ void PauseMenu::DrawInventoryActionMenu()
         std::wstring line = m_currentItemActions[i];
         if (i == m_itemActionCursor)
         {
-            line = L"▶ " + line;
-            m_renderer.DrawString(boxX + 2, boxY + 1 + i, line, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+            line = L"▶  " + line;
+            //m_renderer.DrawString(boxX + 2, boxY + 1 + i, line, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+            m_renderer.DrawString(boxX + 2, boxY + 1 + i, line);
+            // 제 기준 한글 깨져서 주석 처리
         }
         else
         {
-            line = L"  " + line;
+            line = L"   " + line;
             m_renderer.DrawString(boxX + 2, boxY + 1 + i, line);
         }
     }
@@ -604,7 +600,8 @@ void PauseMenu::DrawSkillBookScreen()
     }
 
     // 하단 안내 메시지
-    m_renderer.DrawString(m_renderer.GetWidth() / 2 + 3, m_renderer.GetHeight() - 4, L"[Enter: 스킬 변경 | ESC: 뒤로 가기]");
+    m_renderer.DrawString(m_renderer.GetWidth() / 2 + 3, m_renderer.GetHeight() - 2, L"[Enter: 스킬 변경 | ESC: 뒤로 가기]");
+    // 하단 안내 문구
 }
 
 void PauseMenu::DrawSkillSelectionScreen()

--- a/Spartale/Source/GameLogic/PauseMenu.cpp
+++ b/Spartale/Source/GameLogic/PauseMenu.cpp
@@ -247,7 +247,8 @@ void PauseMenu::DrawStatDistributionScreen()
     for (size_t i = 0; i < statNames.size(); ++i)
     {
         int currentStatY = contentY + i * 2;
-        std::wstring cursor = L"  ";
+        std::wstring cursor = L"  "; 
+        if (i == m_statSelection)   cursor = L"▶ ";
 
         // 스탯 이름 (왼쪽 정렬)
         m_renderer.DrawString(contentX, currentStatY, cursor + statNames[i]);
@@ -433,7 +434,7 @@ void PauseMenu::DrawInventoryScreen()
     if (!inventory) return;
 
     int boxX = m_renderer.GetWidth() / 2 + 5;
-    int boxY = 9; // 6
+    int boxY = 7; // 6
     int boxInnerWidth = 26;
     int boxHeight = 3;
     const int visibleSlots = 5; // 한 화면에 보여줄 아이템 개수
@@ -445,10 +446,10 @@ void PauseMenu::DrawInventoryScreen()
 
     // 스크롤바 그리기
     if (m_inventoryScrollOffset > 0) {
-        m_renderer.DrawString(boxX + boxInnerWidth + 2, boxY, L"▲");
+        m_renderer.DrawString(boxX + 15, boxY - 1, L"▲");
     }
     if (m_inventoryScrollOffset + visibleSlots < totalSlots) {
-        m_renderer.DrawString(boxX + boxInnerWidth + 2, boxY + (visibleSlots * (boxHeight + 1)) - 1, L"▼");
+        m_renderer.DrawString(boxX + 15, boxY + (visibleSlots * (boxHeight + 1)), L"▼");
     }
 
     // 아이템 목록 그리기
@@ -638,7 +639,7 @@ void PauseMenu::DrawSkillSelectionScreen()
             GameplayAbility* currentSkill = grantedAbilities[skillIndex].get();
 
             // 커서와 스킬 기본 텍스트를 준비
-            std::wstring cursor = (skillIndex == m_skillSelectionListCursor) ? L"▶ " : L"  ";
+            std::wstring cursor = (skillIndex == m_skillSelectionListCursor) ? L"▶  " : L"   ";
             std::wstring skillText = cursor + currentSkill->AbilityName;
 
             bool bIsEquipped = IsSkillEquipped(currentSkill);

--- a/Spartale/Source/GameLogic/Skills/GenericAbility.cpp
+++ b/Spartale/Source/GameLogic/Skills/GenericAbility.cpp
@@ -95,14 +95,14 @@ std::wstring GenericAbility::ActivateAbility(AbilitySystemComponent* SourceASC, 
         {
             // 데미지 또는 비율 기반 힐 로그
             finalLogMessage += actualTarget->Name + L"이(가) "
-                + StringUtils::ConvertToWstring(effectData.effectName) + L" 효과로 "
+                + this->AbilityName + L"(으)로 "
                 + std::to_wstring(static_cast<int>(finalMagnitude))
                 + (effectData.isHeal ? L"을(를) 회복했습니다.\n" : L"의 피해를 입었습니다.\n");
         }
         else if (effectData.magnitudeCalculation == "Flat")
         {
             // 고정 수치 기반 버프/디버프 로그
-            finalLogMessage += actualTarget->Name + L"의 "
+            finalLogMessage += this->AbilityName + L"(으)로 인해 " + actualTarget->Name + L"의 "
                 + StringUtils::ConvertToWstring(effectData.targetAttribute) + L"이(가) "
                 + std::to_wstring(static_cast<int>(abs(finalMagnitude))) // Log 에는 양수로 표시되어야함
                 + (finalMagnitude >= 0 ? L" 만큼 증가했습니다.\n" : L" 만큼 감소했습니다.\n");

--- a/Spartale/Source/GameLogic/Units/Player.cpp
+++ b/Spartale/Source/GameLogic/Units/Player.cpp
@@ -36,22 +36,9 @@ void Player::Initialize()
         MyStats->Intelligence.CurrentValue = 15.f;
         MyStats->Intelligence.BaseValue = 15.f;
     }
-    const std::vector<std::string> allSkillIDs = {
-        "SK_NormalAttack",
-        "SK_PoisonCloud",
-        "SK_Fireball",
-        "SK_TripleSlash",
-        "SK_StrengthBuff",
-        "SK_AgilityDown",
-        "SK_Meditate",
-        "SK_Heal"
-    };
-    for (const auto& id : allSkillIDs)
-    {
-        GetAbilityComponent()->GrantAbility(SkillFactory::CreateSkill(id));
-    }
 
     // 기본 공격만 0번 슬롯에 장착
+    GetAbilityComponent()->GrantAbility(SkillFactory::CreateSkill("SK_NormalAttack"));
     GetAbilityComponent()->EquipAbility(0, this->GetAbilityComponent()->GetGrantedAbility(0));
 
     // Player 위치 및 방향 관련 데이터

--- a/Spartale/Source/GameLogic/Units/Player.h
+++ b/Spartale/Source/GameLogic/Units/Player.h
@@ -25,4 +25,5 @@ private:
     Direction m_direction;
 
 	InventoryComponent m_inventory; // 플레이어의 인벤토리 컴포넌트
+
 };

--- a/Spartale/Spartale.cpp
+++ b/Spartale/Spartale.cpp
@@ -10,13 +10,14 @@
 #include "GameLogic/DataManager.h"
 #include "GameLogic/MainMenu.h"
 
+void PrintWide(const std::wstring& text);
 
 using namespace std;
 
 int main()
 {
-    _setmode(_fileno(stdin),_O_U16TEXT);
-    _setmode(_fileno(stdout),_O_U16TEXT);
+    //_setmode(_fileno(stdin),_O_U16TEXT);
+    //_setmode(_fileno(stdout),_O_U16TEXT);
     ConsoleUtils::ShowConsoleCursor(false);
 
     DataManager::GetInstance().LoadMonsterData("Data/Monsters.json");
@@ -39,9 +40,12 @@ int main()
             }
             case EGameState::World:
             {
-                std:wstring name;
+                std::wstring name; 
+                SetConsoleOutputCP(CP_UTF8);
+
                 system("cls");
-                wcout << L"주인공의 이름을 입력해주세요: ";
+                PrintWide(L"주인공의 이름을 입력해주세요: ");
+
                 ConsoleUtils::ShowConsoleCursor(true);
                 std::wcin >> name;
 
@@ -67,4 +71,10 @@ int main()
     ConsoleUtils::ShowConsoleCursor(true);
 
     return 0;
+}
+
+void PrintWide(const std::wstring & text) {
+    DWORD written;
+    HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+    WriteConsoleW(hConsole, text.c_str(), (DWORD)text.length(), &written, nullptr);
 }

--- a/Spartale/Spartale.cpp
+++ b/Spartale/Spartale.cpp
@@ -10,7 +10,7 @@
 #include "GameLogic/DataManager.h"
 #include "GameLogic/MainMenu.h"
 
-void PrintWide(const std::wstring& text);
+void PrintString(const std::wstring& text, SHORT x, SHORT y);
 
 using namespace std;
 
@@ -44,7 +44,7 @@ int main()
                 SetConsoleOutputCP(CP_UTF8);
 
                 system("cls");
-                PrintWide(L"주인공의 이름을 입력해주세요: ");
+                PrintString(L"주인공의 이름을 입력해주세요: ", 30, 15);
 
                 ConsoleUtils::ShowConsoleCursor(true);
                 std::wcin >> name;
@@ -72,9 +72,11 @@ int main()
 
     return 0;
 }
-
-void PrintWide(const std::wstring & text) {
-    DWORD written;
+void PrintString(const std::wstring & text, SHORT x, SHORT y) {
     HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+    DWORD written;
+
+    COORD pos = { x, y };
+    SetConsoleCursorPosition(hConsole, pos);
     WriteConsoleW(hConsole, text.c_str(), (DWORD)text.length(), &written, nullptr);
 }

--- a/Spartale/Spartale.vcxproj
+++ b/Spartale/Spartale.vcxproj
@@ -184,8 +184,13 @@
     <ClInclude Include="Source\Utils\StringUtils.h" />
   </ItemGroup>
   <ItemGroup>
+    <Media Include="Sounds\Buy_sell.wav" />
+    <Media Include="Sounds\EnemyDown.wav" />
     <Media Include="Sounds\enemy_encounter.wav" />
+    <Media Include="Sounds\Levelup.wav" />
+    <Media Include="Sounds\Meet.wav" />
     <Media Include="Sounds\Move_map.wav" />
+    <Media Include="Sounds\Potion.wav" />
     <Media Include="Sounds\Skills\AbyssBlast_sound.wav" />
     <Media Include="Sounds\Skills\Buff_sound.wav" />
     <Media Include="Sounds\Skills\ElementalMagic_sound.wav" />
@@ -201,6 +206,7 @@
     <Media Include="Sounds\UI\menu_reject2.wav" />
     <Media Include="Sounds\UI\pausemenu_confirm.wav" />
     <Media Include="Sounds\UI\pausemenu_select.wav" />
+    <Media Include="Sounds\Win.wav" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Spartale/Spartale.vcxproj.filters
+++ b/Spartale/Spartale.vcxproj.filters
@@ -69,13 +69,14 @@
     <ClCompile Include="Source\GameLogic\PauseMenu.cpp" />
     <ClCompile Include="Source\GameLogic\Skills\GenericAbility.cpp" />
     <ClCompile Include="Source\GameLogic\Skills\SkillFactory.cpp" />
-    <ClCompile Include="Source\Framework\Inventory\IventoryComponent.cpp" />
     <ClCompile Include="Source\GameLogic\NPCMenu.cpp" />
+    <ClCompile Include="Source\Framework\Inventory\InventoryComponent.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Data\Monsters.json" />
     <None Include="Data\Skills.json" />
     <None Include="Data\Map.json" />
+    <None Include="Data\Item.json" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Utils\DamageUtils.h" />
@@ -122,5 +123,11 @@
     <Media Include="Sounds\Skills\Triplehit_sound.wav" />
     <Media Include="Sounds\Skills\Healing.wav" />
     <Media Include="Sounds\Move_map.wav" />
+    <Media Include="Sounds\Potion.wav" />
+    <Media Include="Sounds\Win.wav" />
+    <Media Include="Sounds\Meet.wav" />
+    <Media Include="Sounds\Levelup.wav" />
+    <Media Include="Sounds\EnemyDown.wav" />
+    <Media Include="Sounds\Buy_sell.wav" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- AbilitySystemComponent.h - allSkillIDs 스킬 이름 9개(일반 공격 제외)를 저장한 vector<string> 선언
- AbilitySystemComponent::CheckAndProcessLevelUp 함수: 레벨업 체크 함수 안에 레벨에 맞는 스킬 습득하는 로직 추가
- GenericAbility::ActivateAbility 함수: 전투 시 출력되는 로그에 스킬 이름을 표시하는 것으로 수정