### PR TITLE
아이템 추가, 루트테이블 수정

### DIFF
--- a/Spartale/Data/Item.json
+++ b/Spartale/Data/Item.json
@@ -11,16 +11,16 @@
       "value": 50
     }
   },
-  "consume_big_hp_potion_01": {
+  "consume_hp_potion_02": {
     "name": "대형 체력 포션",
     "description": "사용 시 체력을 150 회복합니다.",
     "type": "Consumable",
-    "price": 20,
+    "price": 50,
     "isStackable": true,
     "maxStackSize": 99,
     "effectData": {
       "effectType": "HEAL_HP",
-      "value": 150
+      "value": 300
     }
   },
   "consume_mp_potion_01": {
@@ -35,7 +35,7 @@
       "value": 60
     }
   },
-  "consume_big_mp_potion_01": {
+  "consume_mp_potion_02": {
     "name": "대형 마나 포션",
     "description": "사용 시 마나를 170 회복합니다.",
     "type": "Consumable",
@@ -51,7 +51,7 @@
     "name": "힘 강화 물약",
     "description": "일정 시간 동안 힘을 15 증가시킵니다.",
     "type": "Consumable",
-    "price": 15,
+    "price": 50,
     "isStackable": true,
     "maxStackSize": 20,
     "effectData": {
@@ -65,7 +65,7 @@
     "name": "마법 강화 물약",
     "description": "일정 시간 동안 지능을 15 증가시킵니다.",
     "type": "Consumable",
-    "price": 15,
+    "price": 50,
     "isStackable": true,
     "maxStackSize": 20,
     "effectData": {
@@ -77,7 +77,7 @@
   },
   "consume_def_boost_01": {
     "name": "방어 강화 물약",
-    "description": "일정 시간 동안 방어력을 8 증가시킵니다.",
+    "description": "일정 시간 동안 방어력을 10 증가시킵니다.",
     "type": "Consumable",
     "price": 18,
     "isStackable": true,
@@ -85,13 +85,13 @@
     "effectData": {
       "effectType": "BUFF_STAT",
       "targetStat": "DEFENCE",
-      "value": 8,
+      "value": 10,
       "duration": 5
     }
   },
-  "consume_MGdef_boost_01": {
+  "consume_MGRS_boost_01": {
     "name": "마법저항력 강화 물약",
-    "description": "일정 시간 동안 마법저항력을 8 증가시킵니다.",
+    "description": "일정 시간 동안 마법저항력을 10 증가시킵니다.",
     "type": "Consumable",
     "price": 18,
     "isStackable": true,
@@ -99,7 +99,7 @@
     "effectData": {
       "effectType": "BUFF_STAT",
       "targetStat": "MAGIC_RESISTANCE",
-      "value": 16,
+      "value": 10,
       "duration": 5
     }
   },
@@ -107,7 +107,7 @@
     "name": "청동 검",
     "description": "초보자에게 적합한 기본적인 검.",
     "type": "Equipment",
-    "price": 50,
+    "price": 250,
     "isStackable": false,
     "maxStackSize": 1,
     "equipmentData": {
@@ -122,7 +122,7 @@
     "name": "강철 도끼",
     "description": "묵직한 무게와 파괴력을 자랑하는 도끼.",
     "type": "Equipment",
-    "price": 80,
+    "price": 380,
     "isStackable": false,
     "maxStackSize": 1,
     "equipmentData": {
@@ -137,7 +137,7 @@
     "name": "맹독 암살자의 단검",
     "description": "맹독 암살자의 어둠마법이 부여되어있다.",
     "type": "Equipment",
-    "price": 70,
+    "price": 380,
     "isStackable": false,
     "maxStackSize": 1,
     "equipmentData": {
@@ -150,11 +150,57 @@
       }
     }
   },
+  "equip_thunderh's_orb_sword_01": {
+    "name": "번개 매의 번개오브",
+    "description": "번개매의 마법 원천인 오브이다.",
+    "type": "Equipment",
+    "price": 470,
+    "isStackable": false,
+    "maxStackSize": 1,
+    "equipmentData": {
+      "equipmentType": "WEAPON",
+      "statBonuses": {
+        "INTELLIGENCE": 80,
+        "MP": 150
+      }
+    }
+  },
+  "equip_skeleton's_sword_01": {
+    "name": "스켈레톤의 암흑대검",
+    "description": "스켈레톤이 쓰던 암흑대검이다. 장착하면 체력이 내려갈것 같다.",
+    "type": "Equipment",
+    "price": 550,
+    "isStackable": false,
+    "maxStackSize": 1,
+    "equipmentData": {
+      "equipmentType": "WEAPON",
+      "statBonuses": {
+        "STRENGTH": 70,
+        "CRITICAL_HIT_CHANCE": 10
+      }
+    }
+  },
+  "equip_Specter's_sword_01": {
+    "name": "스펙터의 얼어 붙은 단검",
+    "description": "스펙터가 쓰던 얼어 붙은 단검이다. 손이 시렵다..",
+    "type": "Equipment",
+    "price": 600,
+    "isStackable": false,
+    "maxStackSize": 1,
+    "equipmentData": {
+      "equipmentType": "WEAPON",
+      "statBonuses": {
+        "STRENGTH": 20,
+        "AGILITY": 30,
+        "CRITICAL_HIT_CHANCE": 20
+      }
+    }
+  },
   "equip_armor_chest_01": {
     "name": "가죽 갑옷",
     "description": "가볍고 질겨 기본적인 보호를 제공한다.",
     "type": "Equipment",
-    "price": 40,
+    "price": 180,
     "isStackable": false,
     "maxStackSize": 1,
     "equipmentData": {
@@ -169,7 +215,7 @@
     "name": "마법사의 로브",
     "description": "마법사에게 적합한 가벼운 로브.",
     "type": "Equipment",
-    "price": 60,
+    "price": 360,
     "isStackable": false,
     "maxStackSize": 1,
     "equipmentData": {
@@ -181,11 +227,28 @@
       }
     }
   },
+  "equip_thief_robe_01": {
+    "name": "도적의 로브",
+    "description": "도적이 쓰던 가벼운 로브.",
+    "type": "Equipment",
+    "price": 360,
+    "isStackable": false,
+    "maxStackSize": 1,
+    "equipmentData": {
+      "equipmentType": "ARMOR",
+      "statBonuses": {
+        "AGILITY": 10,
+        "DEFENSE": 5,
+        "MAGIC_RESISTANCE": 5,
+        "CRITICAL_HIT_CHANCE": 10
+      }
+    }
+  },
   "equip_armor_plate_01": {
     "name": "무쇠 갑옷 골렘의 투구",
     "description": "골렘의 거대한 투구를 입는다.",
     "type": "Equipment",
-    "price": 120,
+    "price": 650,
     "isStackable": false,
     "maxStackSize": 1,
     "equipmentData": {
@@ -197,11 +260,46 @@
       }
     }
   },
-  "equip_accessory_ring_01": {
-    "name": "민첩의 반지",
+  "equip_zombie's_plate_01": {
+    "name": "좀비가 입던 빤쓰",
+    "description": "뭔가 엄청난 마력이 느껴진다...",
+    "type": "Equipment",
+    "price": 880,
+    "isStackable": false,
+    "maxStackSize": 1,
+    "equipmentData": {
+      "equipmentType": "ARMOR",
+      "statBonuses": {
+        "HP": -80,
+        "INTELLIGENCE": 40,
+        "MP": 100,
+        "MAGIC_RESISTANCE": 50,
+        "DEFENCE": 30
+      }
+    }
+  },
+  "equip_wisplight's_plate_01": {
+    "name": "위습의 안개 디퓨져",
+    "description": "위습이 항상 가지고 다니던 안개 발생 장치(?)이다.",
+    "type": "Equipment",
+    "price": 820,
+    "isStackable": false,
+    "maxStackSize": 1,
+    "equipmentData": {
+      "equipmentType": "ARMOR",
+      "statBonuses": {
+        "AGILITY": 30,
+        "DEFENSE": 15,
+        "MAGIC_RESISTANCE": 15,
+        "CRITICAL_HIT_CHANCE": 20
+      }
+    }
+  },
+  "equip_thief_ring_01": {
+    "name": "좀도둑의 반지",
     "description": "착용자의 몸놀림을 한결 가볍게 만들어준다.",
     "type": "Equipment",
-    "price": 75,
+    "price": 275,
     "isStackable": false,
     "maxStackSize": 1,
     "equipmentData": {
@@ -212,11 +310,11 @@
       }
     }
   },
-  "equip_accessory_necklace_01": {
-    "name": "지혜의 반지",
+  "equip_accessory_ring_01": {
+    "name": "관측자의 반지",
     "description": "지식을 탐구하는 자에게 영감을 준다.",
     "type": "Equipment",
-    "price": 90,
+    "price": 290,
     "isStackable": false,
     "maxStackSize": 1,
     "equipmentData": {
@@ -227,11 +325,11 @@
       }
     }
   },
-  "equip_accessory_bracelet_01": {
+  "equip_paladin's_ring_01": {
     "name": "팔라딘의 반지",
     "description": "착용자의 신체를 강건하게 만든다.",
     "type": "Equipment",
-    "price": 85,
+    "price": 285,
     "isStackable": false,
     "maxStackSize": 1,
     "equipmentData": {
@@ -240,6 +338,53 @@
         "DEFENCE": 15,
         "MAGIC_RESISTANCE": 15,
         "HP": 60
+      }
+    }
+  },
+  "equip_skeleton's_ring_01": {
+    "name": "스켈레톤 갈비뼈 반지",
+    "description": "뼈로만든 반지가 가벼워 뭔가 민첩해진거같기도...",
+    "type": "Equipment",
+    "price": 600,
+    "isStackable": false,
+    "maxStackSize": 1,
+    "equipmentData": {
+      "equipmentType": "ACCESSORY",
+      "statBonuses": {
+        "AGILITY": 30,
+        "CRITICAL_HIT_CHANCE": 35,
+        "CRITICAL_HIT_DAMAGE_MULTIPLIER": 1
+      }
+    }
+  },
+  "equip_zombie's_ring_01": {
+    "name": "음침한 좀비의 반지",
+    "description": "내몸이... 좀비가 되는거같아..",
+    "type": "Equipment",
+    "price": 660,
+    "isStackable": false,
+    "maxStackSize": 1,
+    "equipmentData": {
+      "equipmentType": "ACCESSORY",
+      "statBonuses": {
+        "HP": 350
+      }
+    }
+  },
+  "equip_specter's_ring_01": {
+    "name": "스펙터 발톱 반지",
+    "description": "스펙터의 마력이 들어가 마력수준이 한층 높아진다.",
+    "type": "Equipment",
+    "price": 730,
+    "isStackable": false,
+    "maxStackSize": 1,
+    "equipmentData": {
+      "equipmentType": "ACCESSORY",
+      "statBonuses": {
+        "DEFENCE": 15,
+        "MAGIC_RESISTANCE": 40,
+        "HP": 100,
+        "INTELLIGENCE": 50
       }
     }
   }

--- a/Spartale/Data/Monsters.json
+++ b/Spartale/Data/Monsters.json
@@ -11,7 +11,7 @@
     "skills": [
       "SK_NormalAttack"
     ],
-    "loottable": [ "equip_armor_chest_01", "consume_hp_potion_01" ]
+    "loottable": [ "equip_armor_chest_01", "consume_hp_potion_01", "consume_mp_potion_01" ]
   },
   "Fanged_Spider": {
     "name": "독니 거미",
@@ -25,7 +25,8 @@
     "skills": [
       "SK_NormalAttack",
       "SK_PoisonCloud"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_01", "consume_hp_potion_01", "consume_mp_potion_01" ]
   },
   "Prairie_Wolf": {
     "name": "초원 늑대",
@@ -39,7 +40,8 @@
     "skills": [
       "SK_NormalAttack",
       "SK_TripleSlash"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_01", "consume_hp_potion_01", "equip_weapon_sword_01", "equip_armor_chest_01", "consume_mp_potion_01" ]
   },
   "Orc_Warrior": {
     "name": "오크 전사",
@@ -54,7 +56,8 @@
       "SK_NormalAttack",
       "SK_StrengthBuff",
       "SK_TripleSlash"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_01", "consume_hp_potion_01", "equip_weapon_axe_01", "consume_mp_potion_01" ]
   },
   "Forest_Rogue": {
     "name": "숲의 부랑자",
@@ -69,7 +72,8 @@
       "SK_NormalAttack",
       "SK_Heal",
       "SK_StrengthBuff"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_01", "consume_hp_potion_01", "equip_weapon_axe_01" ]
   },
   "Hound_Pack_Leader": {
     "name": "사냥개 무리 우두머리",
@@ -83,7 +87,8 @@
     "skills": [
       "SK_NormalAttack",
       "SK_TripleSlash"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_01", "consume_hp_potion_01", "equip_weapon_axe_01", "equip_armor_chest_01", "equip_armor_robe_01" ]
   },
   "Venom_Assassin": {
     "name": "맹독 암살자",
@@ -97,7 +102,8 @@
     "skills": [
       "SK_StrengthBuff",
       "SK_PoisonCloud"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_02", "consume_hp_potion_02", "equip_thief_robe_01", "equip_thief_ring_01", "equip_weapon_VA_sword_01" ]
   },
   "Stonehide_Dwarf": {
     "name": "돌껍질 드워프",
@@ -110,7 +116,8 @@
     "magicResistance": 0,
     "skills": [
       "SK_NormalAttack"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_02", "consume_hp_potion_02", "equip_weapon_axe_01"]
   },
   "Thunder_Hawk": {
     "name": "번개 매",
@@ -125,7 +132,8 @@
       "SK_Heal",
       "SK_ArcaneBlast",
       "SK_Meditate"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_02", "consume_hp_potion_02", "equip_thunderh's_orb_sword_01", "equip_accessory_ring_01"]
   },
   "Ironclad_Golem": {
     "name": "무쇠 갑옷 골렘",
@@ -139,7 +147,8 @@
     "skills": [
       "SK_NormalAttack",
       "SK_Judgment"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_02", "consume_hp_potion_02", "equip_armor_plate_01", "equip_paladin's_ring_01" ]
   },
   "Frail_Skeleton": {
     "name": "약골 스켈레톤",
@@ -154,7 +163,8 @@
       "SK_NormalAttack",
       "SK_PoisonCloud",
       "SK_Fireball"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_02", "consume_hp_potion_02", "equip_skeleton's_ring_01", "equip_skeleton's_sword_01" ]
   },
   "Gloomy_Zombie": {
     "name": "음침한 좀비",
@@ -169,7 +179,8 @@
       "SK_TripleSlash",
       "SK_NormalAttack",
       "SK_PoisonCloud"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_02", "consume_hp_potion_02", "equip_zombie's_plate_01", "equip_zombie's_ring_01"]
   },
   "Shadow_Wisplight": {
     "name": "어둠의 위스프",
@@ -184,7 +195,8 @@
       "SK_Meditate",
       "SK_ArcaneBlast",
       "SK_AbyssalCollapse"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_02", "consume_hp_potion_02", "equip_wisplight's_plate_01", "equip_armor_robe_01"]
   },
   "Frozen_Specter": {
     "name": "얼어붙은 스펙터",
@@ -200,10 +212,11 @@
       "SK_Meditate",
       "SK_AbyssalCollapse",
       "SK_Fireball"
-    ]
+    ],
+    "loottable": [ "consume_mp_potion_02", "consume_hp_potion_02", "equip_specter's_ring_01", "equip_Specter's_sword_01" ]
   },
   "Ancient_Dragon": {
-    "name": "고대 드래곤",
+    "name": "고대 드래곤 데스페라도",
     "level": 15,
     "hp": 666,
     "strength": 111,

--- a/Spartale/Source/GameLogic/BattleManager.cpp
+++ b/Spartale/Source/GameLogic/BattleManager.cpp
@@ -215,7 +215,7 @@ void BattleManager::Update()
             m_bIsOne = true;
             LogAndWait(m_monster->Name + L"이 몸을 일으켜세운다.");
             LogAndWait(m_monster->Name + L"이 깨어났다.");
-            m_monster->Name = L"깨어난 드래곤";
+            m_monster->Name = L"깨어난 드래곤 데스페라도";
             AttributeSet* monStats = m_monster->GetAbilityComponent()->GetAttributeSet();
             monStats->Level = 20;
             monStats->HP = FAttributeData(999);


### PR DESCRIPTION
+어린 고블린

가죽 갑옷
체력 포션
마나 포션
+독니 거미

마나 포션
체력 포션
마나 포션
+초원 늑대

마나 포션
체력 포션
+청동 검

가죽 갑옷
마나 포션
+오크 전사

마나 포션
체력 포션
강철 도끼
마나 포션
+숲의 부랑자

마나 포션
체력 포션
강철 도끼
+사냥개 무리 우두머리

마나 포션
체력 포션
강철 도끼
가죽 갑옷
마법사의 로브
+맹독 암살자

대형 마나 포션
대형 체력 포션
도적의 로브
좀도둑의 반지
맹독 암살자의 단검
+돌껍질 드워프

대형 마나 포션
대형 체력 포션
강철 도끼
+번개 매

대형 마나 포션
대형 체력 포션
번개 매의 번개오브
관측자의 반지
+무쇠 갑옷 골렘

대형 마나 포션
대형 체력 포션
무쇠 갑옷 골렘의 투구
팔라딘의 반지
+약골 스켈레톤

대형 마나 포션
대형 체력 포션
스켈레톤 갈비뼈 반지
스켈레톤의 암흑대검
+음침한 좀비

대형 마나 포션
대형 체력 포션
좀비가 입던 빤쓰
음침한 좀비의 반지
+어둠의 위스프

대형 마나 포션
대형 체력 포션
위습의 안개 디퓨져
마법사의 로브
+얼어붙은 스펙터

대형 마나 포션
대형 체력 포션
스펙터 발톱 반지