### PR TITLE
fix: 구매 커서 이동시 아이템 정보 유지 버그 수정

### DIFF
--- a/Spartale/Source/GameLogic/PauseMenu.cpp
+++ b/Spartale/Source/GameLogic/PauseMenu.cpp
@@ -1273,10 +1273,17 @@ void PauseMenu::DrawShopBuyScreen()
         }
     }
 
+    const ItemData* selectedItemData = nullptr; // 기본적으로는 비어있음
+
+    // 현재 커서가 유효한 아이템을 가리키고 있는지 확인
+    if (m_shopBuyCursor >= 0 && m_shopBuyCursor < shopData->itemIds.size()) {
+        selectedItemData = DataManager::GetInstance().GetItemData(shopData->itemIds[m_shopBuyCursor]);
+    }
+
     m_renderer.DrawString(m_renderer.GetWidth() / 2 + 3, m_renderer.GetHeight() - 2, L"[Enter: 구매 | ESC: 뒤로 가기]");
 
     // 아이템 정보창은 항상 그림
-    DrawItemInfoBox(false);
+    DrawItemInfoBox(selectedItemData, false);
 
     // 피드백 메시지 표시
     if (!m_feedbackMessage.empty() && GetTickCount64() < m_feedbackMessageEndTime)
@@ -1392,11 +1399,18 @@ void PauseMenu::DrawInventoryScreen(bool bIsSellMode)
             m_renderer.DrawString(boxX + 2, currentY + 1, L"( 비어있음 )");
         }
     }
+    
+    const InventorySlot* selectedSlot = inventory->GetSlotAtIndex(m_inventorySlotSelection);
+    const ItemData* selectedItemData = nullptr;
+    if (selectedSlot)
+    {
+        selectedItemData = selectedSlot->pItemData; // 슬롯에 캐싱된 포인터를 사용
+    }
 
+    // 아이템 정보창 및 피드백 메시지 처리
     m_renderer.DrawString(m_renderer.GetWidth() / 2 + 3, m_renderer.GetHeight() - 2, L"[Enter: 선택 | ESC: 뒤로 가기]");
 
-    // 아이템 정보창은 항상 그림
-    DrawItemInfoBox(bIsSellMode);
+    DrawItemInfoBox(selectedSlot ? selectedSlot->pItemData : nullptr, bIsSellMode);
 }
 
 void PauseMenu::DrawInventoryActionMenu()
@@ -1490,48 +1504,37 @@ void PauseMenu::DrawInventoryDropPrompt()
     }
 }
 
-void PauseMenu::DrawItemInfoBox(bool bIsSellMode)
+void PauseMenu::DrawItemInfoBox(const ItemData* data, bool bIsSellMode)
 {
-    InventoryComponent* inventory = m_player.GetInventory();
-    if (!inventory) return;
+	if (!data) return;
 
-    // 현재 커서가 가리키는 슬롯의 정보를 가져옵니다.
-    const InventorySlot* slot = inventory->GetSlotAtIndex(m_inventorySlotSelection);
-    if (!slot || slot->Quantity == 0) return; // 슬롯이 비어있거나 아이템이 없으면 그리지 않음
-
-    const ItemData* data = DataManager::GetInstance().GetItemData(slot->ItemID);
-    if (!data) return;
-
-    // --- 1. 레이아웃 및 박스 그리기 ---
+    // --- 레이아웃 및 박스 그리기 ---
     int boxY = m_renderer.GetHeight() - 9;
     int boxX = m_renderer.GetWidth() / 2 + 3;
     int boxWidth = m_renderer.GetWidth() - boxX - 10;
 
-    // 박스 테두리 그리기
     m_renderer.DrawString(boxX, boxY, L"┌" + std::wstring(boxWidth, L'─') + L"┐");
     for (int i = 1; i < 5; ++i) {
         m_renderer.DrawString(boxX, boxY + i, L"│" + std::wstring(boxWidth, L' ') + L"│");
     }
     m_renderer.DrawString(boxX, boxY + 5, L"└" + std::wstring(boxWidth, L'─') + L"┘");
 
-    // --- 2. 박스 안에 내용 채우기 ---
+    // --- 박스 안에 내용 채우기 ---
     int contentX = boxX + 2;
     int contentY = boxY + 1;
 
-    // 아이템 이름 표시
+    // 2. 이제 'data'는 함수 내부에서 새로 선언하는 것이 아니라,
+    //    매개변수로 받은 'data'를 그대로 사용합니다.
     std::wstring title = L"[" + data->Name + L"]";
     m_renderer.DrawString(contentX, contentY, title);
 
-    // bIsSellMode 값에 따라 판매가(60%) 또는 일반 구매가를 계산합니다.
     float priceToShow = bIsSellMode ? (data->Price * 0.6f) : data->Price;
     std::wstring price = std::to_wstring(static_cast<int>(priceToShow)) + L" G";
-
     m_renderer.DrawString(contentX + boxWidth - price.length() - 1, contentY, price);
     contentY++;
 
-    // 아이템 설명 표시
     m_renderer.DrawString(contentX, contentY, data->Description);
-    contentY += 2; // 설명과 효과 사이에 한 줄 띄우기
+    contentY += 2;
 
     // --- 3. 아이템 타입에 따라 다른 상세 정보 표시 ---
 

--- a/Spartale/Source/GameLogic/PauseMenu.h
+++ b/Spartale/Source/GameLogic/PauseMenu.h
@@ -89,7 +89,7 @@ private:
     void DrawInventoryScreen(bool bIsSellMode = false);
     void DrawInventoryActionMenu();
     void DrawInventoryDropPrompt();
-    void DrawItemInfoBox(bool bIsSellMode = false);
+    void DrawItemInfoBox(const ItemData* itemData, bool bIsSellMode = false);
 
     // --- 헬퍼 함수 ---
     void ClearRightPane();


### PR DESCRIPTION
## 🐛 문제점 및 해결

**문제점**
상점의 '구매' 화면에서 방향키로 아이템 선택을 변경해도, 화면 하단의 아이템 상세 정보창의 내용이 처음 선택했던 아이템으로 고정되어 갱신되지 않는 문제가 있었습니다.

**해결 방안**
-   **원인:** `DrawItemInfoBox` 함수가 구매 목록의 커서(`m_shopBuyCursor`)가 아닌, 잘못된 변수를 참조하고 있던 것이 원인이었습니다.
-   **수정:** `DrawItemInfoBox` 함수가 표시할 아이템 정보를 직접 인자로 받도록 구조를 변경하여, 호출하는 쪽(`DrawShopBuyScreen`)에서 올바른 아이템 데이터를 전달하도록 수정했습니다.

## ✅ 테스트 방법

1.  상점 '구매' 화면으로 진입합니다.
2.  방향키를 위아래로 움직여 다른 아이템을 선택합니다.
3.  **예상 결과:** 커서가 가리키는 아이템에 맞춰 하단 정보창의 내용(이름, 설명, 가격 등)이 실시간으로 바뀌는지 확인합니다.